### PR TITLE
Add Debian 11 image

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -69,5 +69,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}
           short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -19,6 +19,7 @@ jobs:
           - centos7-ansible
           - centos8-ansible
           - rocky8-ansible
+          - debian11-ansible
           - debian10-ansible
           - debian9-ansible
           - fedora-ansible

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -27,6 +27,7 @@ jobs:
           - oracle7-ansible
           - ubuntu1804-ansible
           - ubuntu2004-ansible
+
     steps:
       -
         name: Checkout
@@ -49,23 +50,24 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest
       -
         name: Update repo description
         uses: peter-evans/dockerhub-description@v2
+        if: github.repository == 'rndmh3ro/docker-ansible'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: rndmh3ro/docker-${{ matrix.dockerimage }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}
           short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/alpine-ansible-latest.yml
+++ b/.github/workflows/alpine-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/amazon-ansible-latest.yml
+++ b/.github/workflows/amazon-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/arch-ansible-latest.yml
+++ b/.github/workflows/arch-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/centos7-ansible-latest.yml
+++ b/.github/workflows/centos7-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/centos8-ansible-latest.yml
+++ b/.github/workflows/centos8-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/debian10-ansible-latest.yml
+++ b/.github/workflows/debian10-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/debian11-ansible-latest.yml
+++ b/.github/workflows/debian11-ansible-latest.yml
@@ -1,0 +1,52 @@
+name: debian11-ansible-latest
+on:
+  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    paths:
+      - 'debian11-ansible-latest/**'
+  pull_request:
+    paths:
+      - 'debian11-ansible-latest/**'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerimage:
+          - debian11-ansible
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and export to Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.dockerimage }}-latest
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+      -
+        name: Test
+        run: |
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.dockerimage }}-latest
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/debian9-ansible-latest.yml
+++ b/.github/workflows/debian9-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/fedora-ansible-latest.yml
+++ b/.github/workflows/fedora-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/opensuse_tumbleweed-ansible-latest.yml
+++ b/.github/workflows/opensuse_tumbleweed-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/openwrt-ansible-latest.yml
+++ b/.github/workflows/openwrt-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/oracle7-ansible-latest.yml
+++ b/.github/workflows/oracle7-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/rocky8-ansible-latest.yml
+++ b/.github/workflows/rocky8-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/ubuntu1804-ansible-latest.yml
+++ b/.github/workflows/ubuntu1804-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/.github/workflows/ubuntu2004-ansible-latest.yml
+++ b/.github/workflows/ubuntu2004-ansible-latest.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           context: ${{ matrix.dockerimage }}-latest
           load: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Test
         run: |
-          docker run --rm rndmh3ro/docker-${{ matrix.dockerimage }}:test
+          docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:test
       -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.dockerimage }}-latest
           push: true
-          tags: rndmh3ro/docker-${{ matrix.dockerimage }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docker-${{ matrix.dockerimage }}:latest

--- a/debian11-ansible-latest/Dockerfile
+++ b/debian11-ansible-latest/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:bullseye
+LABEL maintainer="Sebastian Gumprich"
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+      python3 python3-yaml sudo \
+      curl gcc python3-pip python3-dev libffi-dev libssl-dev systemd
+RUN pip install --no-cache-dir --upgrade cffi && \
+    pip install --no-cache-dir ansible
+
+RUN apt-get -f -y --auto-remove remove \
+      gcc python3-pip python3-dev libffi-dev libssl-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /usr/share/doc /usr/share/man
+
+# Install Ansible inventory file
+RUN mkdir -p /etc/ansible \
+    && echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+CMD [ "ansible-playbook", "--version" ]


### PR DESCRIPTION
Hello!

I noticed there is an issue re: support for Debian 11 image at https://github.com/dev-sec/ansible-collection-hardening/issues/527. Since I frequently use the collection, I would like to see Debian 11 is supported by the collection.

In this PR, I tried to create `Dockerfile` for creating Debian 11 image and updated the CI (GitHub Actions) as well.
I took liberty to replace a part of image name with `DOCKERHUB_USERNAME` variable so I can build and push the image to my own Docker Hub repository. 

Currently, the CI successfully built and pushed the image to Docker Hub. However, I'm still not able to pass the Molecule tests at https://github.com/dev-sec/ansible-collection-hardening using the Debian 11 image.